### PR TITLE
feature: add interactive case analytics header and status visualization

### DIFF
--- a/Server/main.py
+++ b/Server/main.py
@@ -26,7 +26,37 @@ ALLOWED_EXTENSIONS = {
     ".zip", ".tar", ".gz",                             # archives
 }
 
+
 MAX_FILE_SIZE = 500 * 1024 * 1024  # 500 MB
+
+@app.get("/api/stats")
+async def get_case_stats():
+    try:
+        from supabase import create_client
+        url = os.getenv("SUPABASE_URL")
+        key = os.getenv("SUPABASE_ANON_KEY")
+
+        if not url or not key:
+            raise HTTPException(status_code=500, detail="Supabase credentials not configured.")
+
+        client = create_client(url, key)
+        response = client.table("cases").select("status").execute()
+        cases = response.data
+
+        total = len(cases)
+        pending = sum(1 for c in cases if (c.get("status") or "").lower() == "pending")
+        verified = sum(1 for c in cases if (c.get("status") or "").lower() == "verified")
+
+        return {
+            "total": total,
+            "pending": pending,
+            "verified": verified,
+            "reports_generated": verified
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
 @app.post("/api/analyze")
 async def run_forensic_pipeline(file: UploadFile = File(...)):

--- a/Server/requirements.txt
+++ b/Server/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 python-multipart
+supabase

--- a/client/app/dashboard/page.tsx
+++ b/client/app/dashboard/page.tsx
@@ -118,6 +118,13 @@ export default function DashboardPage() {
 
   const chartData = buildChartData(caseHistory);
 
+  const stats = {
+  total: caseHistory.length,
+  pending: caseHistory.filter((c) => c.status?.toLowerCase() === "pending").length,
+  verified: caseHistory.filter((c) => c.status?.toLowerCase() === "verified").length,
+  reportsGenerated: caseHistory.filter((c) => c.status?.toLowerCase() === "verified").length,
+  };
+
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100 p-6 font-sans">
       <header className="flex justify-between items-start mb-10 border-b border-slate-800 pb-6">
@@ -161,6 +168,25 @@ export default function DashboardPage() {
           </div>
         </div>
       </header>
+
+      {/* Analytics Summary Header */}
+      <motion.section
+        initial={{ opacity: 0, y: -10 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8"
+      >
+        {[
+          { label: "Total Cases", value: stats.total, color: "text-emerald-400", border: "border-emerald-500/20" },
+          { label: "Pending", value: stats.pending, color: "text-yellow-400", border: "border-yellow-500/20" },
+          { label: "Verified", value: stats.verified, color: "text-blue-400", border: "border-blue-500/20" },
+          { label: "Reports Generated", value: stats.reportsGenerated, color: "text-purple-400", border: "border-purple-500/20" },
+        ].map((stat) => (
+          <div key={stat.label} className={`bg-slate-900 border ${stat.border} rounded-xl p-4 text-center`}>
+            <p className="text-[10px] uppercase text-slate-500 font-bold tracking-widest mb-2">{stat.label}</p>
+            <p className={`text-3xl font-mono font-bold ${stat.color}`}>{stat.value}</p>
+          </div>
+        ))}
+      </motion.section>
 
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
         <div className="lg:col-span-8 space-y-8">
@@ -255,6 +281,19 @@ export default function DashboardPage() {
                       <span className="text-slate-600 font-mono text-[10px] hidden md:block">
                         {item.hash_value.slice(0, 16)}...
                       </span>
+
+                      <span
+                        className={`text-[10px] font-bold px-2 py-0.5 rounded-full font-mono uppercase border ${
+                          item.status?.toLowerCase() === "verified"
+                            ? "text-emerald-400 bg-emerald-500/10 border-emerald-500/30"
+                            : item.status?.toLowerCase() === "pending"
+                            ? "text-yellow-400 bg-yellow-500/10 border-yellow-500/30"
+                            : "text-slate-400 bg-slate-700/30 border-slate-600/30"
+                        }`}
+                      >
+                        {item.status || "Unknown"}
+                      </span>
+                      
                       <button
                         onClick={() => generateForensicReport(item)}
                         className="opacity-0 group-hover:opacity-100 transition-all bg-emerald-500/10 hover:bg-emerald-500 text-emerald-400 hover:text-white px-3 py-1 rounded border border-emerald-500/20 text-[10px] font-bold uppercase"


### PR DESCRIPTION
Closes #6 

### What's Changed

### 📊Analytics Summary Header
Added 4 stats cards below the dashboard header showing real-time counts:
- Total Cases
- Pending Cases
- Verified Cases
- Reports Generated

### 🎨Color-coded Status Badges
Update the Database Records table to show color-coded status badges:
Verified -> Green badge
Pending -> Yellow badge
Unknown -> Grey badge

### Backend
**Added** `/api/stats` GET endpoint in `Server/main.py` that returns aggregated case counts from Supabase.

<img width="1919" height="810" alt="Screenshot 2026-04-26 183344" src="https://github.com/user-attachments/assets/0746f756-1a78-4ae4-b533-4256ad92b637" />

<img width="1919" height="832" alt="Screenshot 2026-04-26 183420" src="https://github.com/user-attachments/assets/8d559593-caf0-4ba1-8e18-97eccb4bbc65" />

### Testing
- Tested locally with sample data in Supabase.
- Analytics cards update dynamically based on case records.
- Status badges render correctly for all status types.
