### PR TITLE
Harden evidence ingestion: stream uploads, sandbox processing, antivirus & zip‑bomb protection

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -53,6 +53,7 @@ create table cases (
     - `NEXT_PUBLIC_SUPABASE_URL`: Paste your Supabase Project URL.
     - `NEXT_PUBLIC_SUPABASE_ANON_KEY`: Paste your Supabase anon key.
     - `NEXTAUTH_SECRET`: You can generate one by running `openssl rand -base64 32` or just typing a long random string.
+    - `ANALYZE_API_KEY` (optional): shared server-side key used by the authenticated upload proxy.
 
 4.  Install dependencies and start:
     ```bash
@@ -76,6 +77,9 @@ create table cases (
 3.  Open `.env` and fill in the same Supabase details:
     - `SUPABASE_URL`: Your Supabase Project URL.
     - `SUPABASE_ANON_KEY`: Your Supabase anon key.
+    - `ANALYZE_API_KEY` (optional): must match the client-side proxy key if you want backend-side request verification.
+    - `DISABLE_ANTIVIRUS_SCAN` (optional): set to `true` only if you need to bypass local AV scanning in development.
+    - `REQUIRE_ANTIVIRUS_SCAN` (optional): set to `true` to reject uploads when no AV scanner is present.
 
 4.  Install Python dependencies:
     ```bash
@@ -86,6 +90,12 @@ create table cases (
     uvicorn main:app --reload --port 8000
     ```
     The backend will be at `http://localhost:8000`.
+
+### Upload flow
+
+The dashboard now submits evidence to the same-origin Next.js route at `/api/analyze`. That route checks the logged-in investigator session, then forwards the file to the backend with a server-side analyze key.
+
+The backend streams uploads to disk, rejects oversized or suspicious archives, scans with ClamAV if enabled, and runs the forensic engine in a separate worker process.
 
 ---
 

--- a/Server/main.py
+++ b/Server/main.py
@@ -1,8 +1,13 @@
-from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi import FastAPI, UploadFile, File, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-from engine import ForensicEngine
-import asyncio
-import tempfile
+from security import (
+    inspect_archive_limits,
+    remove_file,
+    run_analysis_in_worker,
+    run_antivirus_scan,
+    stream_upload_to_tempfile,
+    validate_analyze_api_key,
+)
 import os
 import time
 
@@ -13,6 +18,7 @@ allowed_origin = os.getenv("ALLOWED_ORIGIN", "http://localhost:3000")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[allowed_origin],
+    allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -59,8 +65,10 @@ async def get_case_stats():
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.post("/api/analyze")
-async def run_forensic_pipeline(file: UploadFile = File(...)):
+async def run_forensic_pipeline(request: Request, file: UploadFile = File(...)):
     try:
+        validate_analyze_api_key(request.headers.get("x-analyze-key"))
+
         ext = os.path.splitext(file.filename or "")[1].lower()
         if ext not in ALLOWED_EXTENSIONS:
             raise HTTPException(
@@ -68,22 +76,17 @@ async def run_forensic_pipeline(file: UploadFile = File(...)):
                 detail=f"File type '{ext}' is not permitted. Allowed types: {', '.join(sorted(ALLOWED_EXTENSIONS))}"
             )
 
-        content = await file.read()
-
-        if len(content) > MAX_FILE_SIZE:
-            raise HTTPException(status_code=413, detail="File exceeds the 500 MB size limit.")
-
-        with tempfile.NamedTemporaryFile(delete=False, suffix=ext) as tmp:
-            tmp.write(content)
-            tmp_path = tmp.name
+        tmp_path = None
+        archive_metadata = None
 
         try:
-            engine = ForensicEngine(tmp_path)
-            report = engine.run_automated_process()
+            tmp_path, _ = await stream_upload_to_tempfile(file, ext)
+            archive_metadata = inspect_archive_limits(tmp_path, file.filename or "")
+            antivirus_result = run_antivirus_scan(tmp_path)
+            report = run_analysis_in_worker(tmp_path)
         finally:
-            os.unlink(tmp_path)
-
-        await asyncio.sleep(2)
+            if tmp_path:
+                remove_file(tmp_path)
 
         return {
             "id": f"CASE-{int(time.time())}",
@@ -99,7 +102,10 @@ async def run_forensic_pipeline(file: UploadFile = File(...)):
             "threat_level": report['threat_level'],
             "status": "COMPLETED",
             "report_generated": True,
-            "findings": f"Advanced Forensic Analysis: {report['metadata']['magic_signature']} detected. Integrity verified via Dual-Hash (SHA256+MD5)."
+            "findings": f"Advanced Forensic Analysis: {report['metadata']['magic_signature']} detected. Integrity verified via Dual-Hash (SHA256+MD5).",
+            "antivirus_scan": antivirus_result,
+            "archive_inspection": archive_metadata,
+            "analysis_mode": "isolated-worker",
         }
     except HTTPException:
         raise

--- a/Server/security.py
+++ b/Server/security.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import gzip
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path
+
+from fastapi import HTTPException, UploadFile
+
+
+DEFAULT_ANALYZE_API_KEY = os.getenv("ANALYZE_API_KEY", "forensic-pro-suite-demo-analyze-key")
+MAX_FILE_SIZE_BYTES = int(os.getenv("MAX_FILE_SIZE_BYTES", str(500 * 1024 * 1024)))
+MAX_ARCHIVE_ENTRIES = int(os.getenv("MAX_ARCHIVE_ENTRIES", "10000"))
+MAX_ARCHIVE_TOTAL_BYTES = int(os.getenv("MAX_ARCHIVE_TOTAL_BYTES", str(2 * 1024 * 1024 * 1024)))
+MAX_ARCHIVE_COMPRESSION_RATIO = float(os.getenv("MAX_ARCHIVE_COMPRESSION_RATIO", "100.0"))
+UPLOAD_CHUNK_SIZE = int(os.getenv("UPLOAD_CHUNK_SIZE", str(64 * 1024)))
+ANALYSIS_TIMEOUT_SECONDS = int(os.getenv("ANALYSIS_TIMEOUT_SECONDS", "120"))
+AV_SCAN_TIMEOUT_SECONDS = int(os.getenv("AV_SCAN_TIMEOUT_SECONDS", "120"))
+
+
+def _truthy(value: str | None) -> bool:
+    return bool(value and value.strip().lower() in {"1", "true", "yes", "on"})
+
+
+def _archive_entry_limit() -> int:
+    return int(os.getenv("MAX_ARCHIVE_ENTRIES", str(MAX_ARCHIVE_ENTRIES)))
+
+
+def _archive_total_limit() -> int:
+    return int(os.getenv("MAX_ARCHIVE_TOTAL_BYTES", str(MAX_ARCHIVE_TOTAL_BYTES)))
+
+
+def _archive_ratio_limit() -> float:
+    return float(os.getenv("MAX_ARCHIVE_COMPRESSION_RATIO", str(MAX_ARCHIVE_COMPRESSION_RATIO)))
+
+
+def validate_analyze_api_key(provided_key: str | None) -> None:
+    if not DEFAULT_ANALYZE_API_KEY:
+        return
+
+    if not provided_key or provided_key != DEFAULT_ANALYZE_API_KEY:
+        raise HTTPException(status_code=401, detail="Unauthorized analyze request.")
+
+
+async def stream_upload_to_tempfile(upload_file: UploadFile, suffix: str) -> tuple[str, int]:
+    total_bytes = 0
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        tmp_path = tmp.name
+        try:
+            while True:
+                chunk = await upload_file.read(UPLOAD_CHUNK_SIZE)
+                if not chunk:
+                    break
+
+                total_bytes += len(chunk)
+                if total_bytes > MAX_FILE_SIZE_BYTES:
+                    raise HTTPException(status_code=413, detail="File exceeds the maximum allowed size.")
+
+                tmp.write(chunk)
+
+            tmp.flush()
+            return tmp_path, total_bytes
+        except Exception:
+            Path(tmp_path).unlink(missing_ok=True)
+            raise
+
+
+def _validate_zip_archive(path: str) -> dict[str, int | float | str]:
+    with zipfile.ZipFile(path) as archive:
+        infos = archive.infolist()
+        entry_count = len(infos)
+        if entry_count > _archive_entry_limit():
+            raise HTTPException(status_code=400, detail="Archive contains too many entries.")
+
+        total_uncompressed = sum(info.file_size for info in infos)
+        total_compressed = sum(max(info.compress_size, 1) for info in infos)
+
+        if total_uncompressed > _archive_total_limit():
+            raise HTTPException(status_code=400, detail="Archive expands beyond the allowed size limit.")
+
+        compression_ratio = total_uncompressed / total_compressed
+        if compression_ratio > _archive_ratio_limit():
+            raise HTTPException(status_code=400, detail="Archive compression ratio is suspiciously high.")
+
+        return {
+            "archive_type": "zip",
+            "entries": entry_count,
+            "expanded_bytes": total_uncompressed,
+            "compressed_bytes": total_compressed,
+            "compression_ratio": round(compression_ratio, 2),
+        }
+
+
+def _validate_tar_archive(path: str) -> dict[str, int | float | str]:
+    with tarfile.open(path, mode="r:*") as archive:
+        members = archive.getmembers()
+        entry_count = len(members)
+        if entry_count > _archive_entry_limit():
+            raise HTTPException(status_code=400, detail="Archive contains too many entries.")
+
+        if any(member.issym() or member.islnk() for member in members):
+            raise HTTPException(status_code=400, detail="Archive contains links that are not allowed.")
+
+        total_uncompressed = sum(member.size for member in members if member.isfile())
+        if total_uncompressed > _archive_total_limit():
+            raise HTTPException(status_code=400, detail="Archive expands beyond the allowed size limit.")
+
+        return {
+            "archive_type": "tar",
+            "entries": entry_count,
+            "expanded_bytes": total_uncompressed,
+            "compressed_bytes": os.path.getsize(path),
+            "compression_ratio": round(total_uncompressed / max(os.path.getsize(path), 1), 2),
+        }
+
+
+def _validate_gzip_archive(path: str) -> dict[str, int | float | str]:
+    expanded_bytes = 0
+    with gzip.open(path, mode="rb") as archive:
+        while True:
+            chunk = archive.read(UPLOAD_CHUNK_SIZE)
+            if not chunk:
+                break
+
+            expanded_bytes += len(chunk)
+            if expanded_bytes > _archive_total_limit():
+                raise HTTPException(status_code=400, detail="Compressed file expands beyond the allowed size limit.")
+
+    compressed_bytes = os.path.getsize(path)
+    return {
+        "archive_type": "gzip",
+        "entries": 1,
+        "expanded_bytes": expanded_bytes,
+        "compressed_bytes": compressed_bytes,
+        "compression_ratio": round(expanded_bytes / max(compressed_bytes, 1), 2),
+    }
+
+
+def inspect_archive_limits(path: str, filename: str) -> dict[str, int | float | str] | None:
+    lowered = filename.lower()
+
+    if zipfile.is_zipfile(path) or lowered.endswith(".zip"):
+        return _validate_zip_archive(path)
+
+    if tarfile.is_tarfile(path) or lowered.endswith((".tar", ".tar.gz", ".tgz")):
+        return _validate_tar_archive(path)
+
+    if lowered.endswith(".gz"):
+        return _validate_gzip_archive(path)
+
+    return None
+
+
+def run_antivirus_scan(path: str) -> dict[str, str]:
+    if _truthy(os.getenv("DISABLE_ANTIVIRUS_SCAN")):
+        return {"engine": "disabled", "status": "skipped"}
+
+    command = os.getenv("AV_SCAN_COMMAND")
+    if command:
+        argv = shlex.split(command)
+        if not argv:
+            raise HTTPException(status_code=500, detail="AV_SCAN_COMMAND is configured but empty.")
+        if "{path}" in command:
+            argv = [part.format(path=path) for part in argv]
+        else:
+            argv.append(path)
+    else:
+        clamscan = shutil.which("clamscan") or shutil.which("clamdscan")
+        if not clamscan:
+            if _truthy(os.getenv("REQUIRE_ANTIVIRUS_SCAN")):
+                raise HTTPException(status_code=503, detail="No antivirus scanner is available on this host.")
+            return {"engine": "unavailable", "status": "skipped"}
+        argv = [clamscan, "--no-summary", path]
+
+    try:
+        completed = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=AV_SCAN_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise HTTPException(status_code=504, detail="Antivirus scan timed out.") from exc
+
+    output = "\n".join(part for part in [completed.stdout.strip(), completed.stderr.strip()] if part)
+    if completed.returncode == 0:
+        return {"engine": Path(argv[0]).name, "status": "clean", "output": output}
+
+    if completed.returncode == 1 or "FOUND" in output.upper():
+        raise HTTPException(status_code=400, detail="File failed malware scan.")
+
+    raise HTTPException(status_code=503, detail=f"Antivirus scan failed: {output or 'unknown error'}")
+
+
+def run_analysis_in_worker(path: str) -> dict:
+    worker_path = Path(__file__).with_name("worker_runner.py")
+    try:
+        completed = subprocess.run(
+            [os.environ.get("PYTHON_EXECUTABLE", os.sys.executable), str(worker_path), path],
+            capture_output=True,
+            text=True,
+            timeout=ANALYSIS_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise HTTPException(status_code=504, detail="Analysis timed out.") from exc
+
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip() or completed.stdout.strip() or "Worker process failed."
+        raise HTTPException(status_code=500, detail=stderr)
+
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=500, detail="Worker returned invalid JSON.") from exc
+
+
+def remove_file(path: str) -> None:
+    Path(path).unlink(missing_ok=True)

--- a/Server/tests/test_security.py
+++ b/Server/tests/test_security.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import asyncio
+import gzip
+import os
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from fastapi import HTTPException
+
+from security import inspect_archive_limits, stream_upload_to_tempfile
+
+
+class FakeUploadFile:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+        self._offset = 0
+
+    async def read(self, size: int = -1) -> bytes:
+        if self._offset >= len(self._payload):
+            return b""
+
+        if size < 0:
+            size = len(self._payload) - self._offset
+
+        chunk = self._payload[self._offset : self._offset + size]
+        self._offset += len(chunk)
+        return chunk
+
+
+class SecurityHelpersTests(unittest.TestCase):
+    def test_stream_upload_to_tempfile_writes_payload(self) -> None:
+        async def run_test() -> None:
+            fake = FakeUploadFile(b"hello world")
+            tmp_path, size = await stream_upload_to_tempfile(fake, ".txt")
+            try:
+                self.assertEqual(size, 11)
+                self.assertEqual(Path(tmp_path).read_bytes(), b"hello world")
+            finally:
+                Path(tmp_path).unlink(missing_ok=True)
+
+        asyncio.run(run_test())
+
+    def test_zip_archive_over_limit_is_rejected(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            with zipfile.ZipFile(tmp_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+                for index in range(12):
+                    archive.writestr(f"entry-{index}.txt", "A" * 8)
+
+            previous_limit = os.environ.get("MAX_ARCHIVE_ENTRIES")
+            os.environ["MAX_ARCHIVE_ENTRIES"] = "10"
+            with self.assertRaises(HTTPException):
+                inspect_archive_limits(tmp_path, "sample.zip")
+            if previous_limit is None:
+                os.environ.pop("MAX_ARCHIVE_ENTRIES", None)
+            else:
+                os.environ["MAX_ARCHIVE_ENTRIES"] = previous_limit
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+    def test_gzip_archive_inspection_reports_expanded_size(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".gz", delete=False) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            with gzip.open(tmp_path, "wb") as archive:
+                archive.write(b"x" * 1024)
+
+            result = inspect_archive_limits(tmp_path, "sample.gz")
+            self.assertIsNotNone(result)
+            self.assertEqual(result["archive_type"], "gzip")
+            self.assertEqual(result["entries"], 1)
+            self.assertGreaterEqual(result["expanded_bytes"], 1024)
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Server/worker_runner.py
+++ b/Server/worker_runner.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import json
+import sys
+
+from engine import ForensicEngine
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(json.dumps({"error": "Usage: worker_runner.py <evidence_path>"}), file=sys.stderr)
+        return 2
+
+    evidence_path = sys.argv[1]
+    report = ForensicEngine(evidence_path).run_automated_process()
+    print(json.dumps(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/client/app/api/analyze/route.ts
+++ b/client/app/api/analyze/route.ts
@@ -1,0 +1,43 @@
+import { authOptions } from "@/lib/auth";
+import { getServerSession } from "next-auth/next";
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+const ANALYZE_PROXY_KEY = process.env.ANALYZE_API_KEY ?? "forensic-pro-suite-demo-analyze-key";
+const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const formData = await request.formData();
+  const file = formData.get("file");
+
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "Missing file upload" }, { status: 400 });
+  }
+
+  const forwardForm = new FormData();
+  forwardForm.append("file", file, file.name);
+
+  const backendResponse = await fetch(`${BACKEND_URL}/api/analyze`, {
+    method: "POST",
+    headers: {
+      "X-Analyze-Key": ANALYZE_PROXY_KEY,
+    },
+    body: forwardForm,
+  });
+
+  const contentType = backendResponse.headers.get("content-type") || "application/json";
+  const payload = await backendResponse.text();
+
+  return new NextResponse(payload, {
+    status: backendResponse.status,
+    headers: {
+      "content-type": contentType,
+    },
+  });
+}

--- a/client/app/api/auth/[...nextauth]/route.ts
+++ b/client/app/api/auth/[...nextauth]/route.ts
@@ -1,43 +1,6 @@
 import NextAuth from "next-auth";
-import CredentialsProvider from "next-auth/providers/credentials";
-import { timingSafeEqual, createHash } from "crypto";
+import { authOptions } from "@/lib/auth";
 
-function safeCompare(a: string, b: string): boolean {
-  // Pad to same length before comparing to avoid length-based timing leaks
-  const bufA = createHash("sha256").update(a).digest();
-  const bufB = createHash("sha256").update(b).digest();
-  return timingSafeEqual(bufA, bufB);
-}
-
-const handler = NextAuth({
-  providers: [
-    CredentialsProvider({
-      name: "Forensics Portal",
-      credentials: {
-        email: { label: "Email", type: "email" },
-        password: { label: "Password", type: "password" }
-      },
-      async authorize(credentials) {
-        const adminEmail = process.env.ADMIN_EMAIL;
-        const adminPassword = process.env.ADMIN_PASSWORD;
-        if (!adminEmail || !adminPassword || !credentials?.email || !credentials?.password) {
-          return null;
-        }
-        const emailMatch = safeCompare(credentials.email, adminEmail);
-        const passwordMatch = safeCompare(credentials.password, adminPassword);
-        if (emailMatch && passwordMatch) {
-          return { id: "1", name: "Lead Investigator", email: adminEmail };
-        }
-        return null;
-      }
-    })
-  ],
-  pages: {
-    signIn: "/login",
-  },
-  session: {
-    strategy: "jwt",
-  },
-});
+const handler = NextAuth(authOptions);
 
 export { handler as GET, handler as POST };

--- a/client/app/dashboard/page.tsx
+++ b/client/app/dashboard/page.tsx
@@ -238,7 +238,7 @@ export default function DashboardPage() {
       formData.append("file", file);
 
       try {
-        const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000"}/api/analyze`, {
+        const response = await fetch("/api/analyze", {
           method: "POST",
           body: formData,
         });

--- a/client/lib/auth.ts
+++ b/client/lib/auth.ts
@@ -1,0 +1,44 @@
+import CredentialsProvider from "next-auth/providers/credentials";
+import { createHash, timingSafeEqual } from "crypto";
+import type { NextAuthOptions } from "next-auth";
+
+function safeCompare(a: string, b: string): boolean {
+  const bufA = createHash("sha256").update(a).digest();
+  const bufB = createHash("sha256").update(b).digest();
+  return timingSafeEqual(bufA, bufB);
+}
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    CredentialsProvider({
+      name: "Forensics Portal",
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(credentials) {
+        const adminEmail = process.env.ADMIN_EMAIL;
+        const adminPassword = process.env.ADMIN_PASSWORD;
+
+        if (!adminEmail || !adminPassword || !credentials?.email || !credentials?.password) {
+          return null;
+        }
+
+        const emailMatch = safeCompare(credentials.email, adminEmail);
+        const passwordMatch = safeCompare(credentials.password, adminPassword);
+
+        if (emailMatch && passwordMatch) {
+          return { id: "1", name: "Lead Investigator", email: adminEmail };
+        }
+
+        return null;
+      },
+    }),
+  ],
+  pages: {
+    signIn: "/login",
+  },
+  session: {
+    strategy: "jwt",
+  },
+};


### PR DESCRIPTION
**Title:** Harden ingestion pipeline — streaming uploads, AV scan, archive limits, worker isolation, and authenticated proxy

**Issue**
This PR and issue #74 comes under GSSoC 26

**Description**
- **Summary:** Secure the evidence ingestion flow by streaming uploads to disk, rejecting oversized or suspicious archives, running antivirus scans if available, executing forensic analysis in an isolated worker process, and routing dashboard uploads through a same-origin, session-checked proxy.
- **Why:** Prevents DoS / resource exhaustion, reduces risk from malicious payloads (malware / zip-bombs), and decouples long-running analysis from the request handler.

**Changes**
- **Backend:** main.py, security.py, worker_runner.py, test_security.py
- **Frontend:** route.ts, page.tsx, route.ts, auth.ts
- **Docs:** SETUP.md
- **New test coverage:** test_security.py (streaming upload + archive checks)

**Implementation notes**
- Streaming upload: `stream_upload_to_tempfile` writes chunks to a temporary file and enforces a configurable `MAX_FILE_SIZE_BYTES`.
- Archive inspection: `inspect_archive_limits` validates zip/tar/gzip entry counts, expanded size, and compression ratio before analysis.
- Antivirus: `run_antivirus_scan` runs a host AV command (auto-enabled unless `DISABLE_ANTIVIRUS_SCAN=true`); `REQUIRE_ANTIVIRUS_SCAN` can force failure when no scanner is present.
- Worker isolation: `worker_runner.py` executes `ForensicEngine` in a subprocess; `run_analysis_in_worker` enforces a timeout.
- Authenticated proxy: client-side route `POST /api/analyze` requires a logged-in `next-auth` session and forwards files to backend with `X-Analyze-Key`.
- Dashboard now posts to the same-origin proxy (`/api/analyze`) instead of calling backend directly.
- Tempfiles are cleaned on all code paths.

**Testing performed**
- Backend unit tests: `python -m unittest discover -s tests` — all tests pass.
<img width="644" height="131" alt="Screenshot 2026-05-16 at 10 22 35 AM" src="https://github.com/user-attachments/assets/6974a5d7-085b-48d2-aaf1-47c981955a0e" />

- Frontend production build: `cd client && npm run build` — build succeeded.
- Manual verification: dashboard upload flow tested locally via UI and logs.
**How to run locally**
- Start backend:
  - `cd Server`
  - `.venv/bin/python -m uvicorn main:app --reload --port 8000`
- Start frontend:
  - `cd client`
  - `npm run dev`
- Run backend tests:
  - `cd Server && .venv/bin/python -m unittest discover -s tests`
- Produce a curl test:
  - `curl -v -F "file=@/path/to/test_evidence.dd" http://localhost:3000/api/analyze` (client proxy will forward to backend)

**New / updated env vars**
- `ANALYZE_API_KEY` — shared key used by client proxy and backend verification (optional; default demo key used if absent).
- `DISABLE_ANTIVIRUS_SCAN` — set to `true` to opt out of local AV scanning (dev only).
- `REQUIRE_ANTIVIRUS_SCAN` — set to `true` to reject uploads if no AV scanner is available.
- `MAX_FILE_SIZE_BYTES`, `MAX_ARCHIVE_ENTRIES`, `MAX_ARCHIVE_TOTAL_BYTES`, `MAX_ARCHIVE_COMPRESSION_RATIO` — runtime limits configurable via env.

**Backward-compatibility & rollout**
- Safe default behavior: if no AV tool is installed, AV step is skipped (unless `REQUIRE_ANTIVIRUS_SCAN=true`).
- Deploy backend and frontend together or set `ANALYZE_API_KEY` accordingly; otherwise client proxy uses demo key.
- Recommend staged rollout: enable `REQUIRE_ANTIVIRUS_SCAN=true` after verifying AV availability in production.

**Risk & mitigation**
- Risk: changed upload flow might break integrations calling backend directly. Mitigation: backend still accepts `X-Analyze-Key` requests — update integrations to use the proxy or present the key.
- Risk: worker subprocess failure modes. Mitigation: timeouts and explicit error mapping; worker output is validated as JSON.

**Files to review**
- security.py — core hardening helpers (streaming, archive checks, AV, worker runner)
- worker_runner.py — isolated analysis runner
- main.py — endpoint wiring and response changes
- route.ts — same-origin proxy + session check
- page.tsx — upload now goes to `/api/analyze`
- SETUP.md — updated instructions and new env vars