### PR TITLE
feat: implement EXIF metadata and geospatial tags extraction pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .vscode/
+.venv/
+__pycache__/
+*.pyc

--- a/Server/engine.py
+++ b/Server/engine.py
@@ -20,6 +20,9 @@ class ForensicEngine:
         metadata["magic_signature"] = file_sig
         metadata["signature_match"] = magic_verified
 
+        print("Extracting Image EXIF Data (if applicable)...")
+        metadata["exif"] = self.extract_image_exif(file_sig)
+
         self.report_data = {
             "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             "evidence_name": os.path.basename(self.evidence_path),
@@ -65,4 +68,20 @@ class ForensicEngine:
             "modified": datetime.datetime.fromtimestamp(stats.st_mtime, tz=datetime.timezone.utc).isoformat(),
             "accessed": datetime.datetime.fromtimestamp(stats.st_atime, tz=datetime.timezone.utc).isoformat(),
             "permissions": oct(stats.st_mode)[-3:]
-        }
+        }
+    
+    def extract_image_exif(self, file_sig: str) -> dict:
+        supported_formats = ["PNG Image", "JPEG Image"]
+        
+        if file_sig not in supported_formats:
+            return {"status": "skipped", "message": "File signature is not a supported image format"}    
+        
+        from utils import extract_exif_data
+        try:
+            with open(self.evidence_path, "rb") as file_handler:
+                image_binary_payload = file_handler.read()
+            
+            return extract_exif_data(image_binary_payload)
+            
+        except Exception as e:
+            return {"status": "error", "message": f"Engine failed to read file bytes: {str(e)}"}

--- a/Server/main.py
+++ b/Server/main.py
@@ -31,7 +31,6 @@ ALLOWED_EXTENSIONS = {
 
 MAX_FILE_SIZE = 500 * 1024 * 1024
 
-
 @app.get("/api/stats")
 async def get_case_stats():
     try:
@@ -104,6 +103,7 @@ async def run_forensic_pipeline(file: UploadFile = File(...)):
             "modified": report['metadata']['modified'],
             "accessed": report['metadata']['accessed'],
             "permissions": report['metadata']['permissions'],
+            "exif_metadata": report['metadata']['exif'],
             "magic_signature": report['metadata']['magic_signature'],
             "threat_level": report['threat_level'],
             "status": "COMPLETED",

--- a/Server/requirements.txt
+++ b/Server/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 python-multipart
 supabase
+exif==1.6.1

--- a/Server/utils.py
+++ b/Server/utils.py
@@ -1,0 +1,52 @@
+from exif import Image
+from typing import Dict, Any, Optional
+
+def extract_exif_data(image_bytes: bytes) -> Dict[str, Any]:
+    try:
+        img = Image(image_bytes)
+        has_metadata = img.has_exif
+        if not has_metadata:
+            return {"status": "skipped", "message": "No EXIF data found."}
+    except Exception as e:
+        error_msg = str(e)
+        if "TiffByteOrder" in error_msg or "unpack operation" in error_msg:
+            return {
+                "status": "skipped", 
+                "message": f"Image file contains non-standard or corrupt metadata byte arrays (AI-generated graphic or screenshot detected)."
+            }
+        return {"status": "error", "message": f"Failed to initialize image parser: {error_msg}"}
+        
+    try:
+        if not hasattr(img, 'gps_latitude') or not hasattr(img, 'gps_longitude'):
+            return {"status": "skipped", "message": "EXIF block present but lacks embedded geospatial tags"}
+            
+        latitude = img.gps_latitude
+        longitude = img.gps_longitude
+        latitude_ref = img.gps_latitude_ref if hasattr(img, 'gps_latitude_ref') else 'N'
+        longitude_ref = img.gps_longitude_ref if hasattr(img, 'gps_longitude_ref') else 'E'
+
+        if not isinstance(latitude, (tuple, list)) or not isinstance(longitude, (tuple, list)):
+            return {"status": "skipped", "message": "EXIF block present but geospatial tags are not in expected format"}
+            
+        if len(latitude) < 3 or len(longitude) < 3:
+            return {"status": "skipped", "message": "EXIF block present but geospatial tags are too short to be valid"}
+            
+        lat_dd = float(latitude[0]) + float(latitude[1]) / 60 + float(latitude[2]) / 3600
+        lon_dd = float(longitude[0]) + float(longitude[1]) / 60 + float(longitude[2]) / 3600
+
+        if latitude_ref == 'S':
+            lat_dd = -lat_dd
+        if longitude_ref == 'W':
+            lon_dd = -lon_dd
+
+        timestamp: Optional[str] = getattr(img, "datetime_original", None)
+
+        return {
+            "status": "success",
+            "latitude": round(lat_dd, 6),
+            "longitude": round(lon_dd, 6),
+            "timestamp": timestamp
+        }
+   
+    except Exception as e:
+        return {"status": "error", "message": f"Failed to extract EXIF data: {str(e)}"}


### PR DESCRIPTION
## Overview
- Resolves #122 
- This PR implements an image EXIF metadata extraction and geospatial coordinate processing pipeline within the forensic analytics suite. The implementation introduces dynamic binary parsing for supported image types (`JPEG` and `PNG`) and translates raw, non-standard camera arrays into standard decimal-degree(DD) format for frontend mapping from degree-minutes-second(DMS).

## Problem & Context
Previously, the forensic pipeline collected basic system file attributes (size, permissions, timestamps, and magic bytes) but missed deeply embedded device telemetry. Adding support for EXIF data introduces two main challenges:
1. Handling files with missing metadata blocks gracefully without dropping `500 Internal Server Errors`.
2. Intercepting library-level crashes caused by non-standard metadata architectures, such as AI-generated graphics or screenshots that lack a valid TIFF Byte Order header (I tested by uploading AI generated images)

## Key Technical Implementations

### 1. High-Level Engine Routing (`Server/engine.py`)
- Integrated an intentional verification step (`extract_image_exif`) within the core engine cycle.
- Restricted processing overhead by performing early validation checks on the parsed file magic signatures, skipping unsupported types instantly.

### 2. Multi-Tier Fault Tolerance (`Server/utils.py`)
- Engineered a dual-stage exception handler to catch library-level runtime crashes explicitly.
- Added key string-matching overrides (`TiffByteOrder`, `unpack operation`) to catch AI structural footprints, cleanly downgrading structural failures into descriptive, non-breaking `"status": "skipped"` messages.
- Handled empty or stripped metadata blocks (common in screenshots or web-optimized social media assets) under a unified fallback gate.

### 3. Coordinate Normalization
- Parsed the standard Degree-Minute-Second (DMS) `list`/`tuple` structures natively out of the image binary.
- Calculated the precise Decimal Degrees ($DD = Degrees + \frac{Minutes}{60} + \frac{Seconds}{3600}$) and adjusted for orientation quadrants using the geospatial hemisphere direction references (`S` and `W`) by multiplying with -1.
- Constrained precision by rounding out to 6 decimal places for reliable spatial plotting.

### 4. API & Workspace Sanitation
- Extended the primary pipeline response schema in `Server/main.py` to deliver the `exif_metadata` map object cleanly to the frontend layout.
- Added strict pinning for `exif==1.6.1` inside `requirements.txt`.
- Configured a comprehensive workspace `.gitignore` to keep local virtual environment payloads (`.venv/`) and binary runtime tracks (`__pycache__/`) out of source control tracking.

---

##  How I Tested

### Test Case 1: Standard AI-Generated Asset (Gemini Output)
- **Input:** Raw AI-generated PNG image file containing custom text chunks but an invalid binary TIFF layout.
- **Result:** Successfully bypassed the empty metadata block check, caught the `ValueError` unpack exception via string inspection, and smoothly returned a handled status:
<img width="707" height="75" alt="image" src="https://github.com/user-attachments/assets/97953f58-84b1-4857-a243-b1eee5aec632" />

### Test Case 2: Privacy-Stripped Web Graphics (Pinterest Asset)
- **Input:** Image downloaded directly from Pinterest where platform privacy filters completely scrubbed the metadata block.
- **Result:** Intercepted seamlessly at line 11 by the has_metadata check, returning a clean fallback block:
<img width="597" height="72" alt="image" src="https://github.com/user-attachments/assets/1f8295a3-3a55-434f-9625-def345e86c68" />

### Test Case 3: Forensic sample asset
- **Input:** Authentic open-source camera photo with active GPS hardware tags intact (https://github.com/ianare/exif-samples/blob/master/jpg/gps/DSCN0010.jpg)
- **Result:** Successfully bypassed all exception gates and structural fallbacks, returning a verified execution path:
<img width="677" height="98" alt="image" src="https://github.com/user-attachments/assets/11829203-06c7-45ab-80f5-2aacbcb3034c" />

