### PR TITLE
add standard issue templates (bug or feature) and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+name: " bug report"
+about: report a reproducible bug or glitch in the forensic pro suite
+title: "[BUG]: "
+labels: ["bug"]
+assignees: ""
+---
+
+###  description
+a clear and concise description of what the bug is.
+
+###  steps to reproduce
+1. go to '...'
+2. click on '...'
+3. scroll down to '...'
+4. see error
+
+###  expected behavior
+a clear and concise description of what you expected to happen.
+
+###  screenshots
+if applicable, add screenshots to help explain your problem.
+
+###  environment
+* os: [e.g. windows, mac, ubuntu]
+* browser: [e.g. chrome, safari]
+* version: [e.g. python 3.10, node 18]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+name: " feature request"
+about: suggest a new feature or enhancement for the project
+title: "[FEATURE]: "
+labels: ["enhancement"]
+assignees: ""
+---
+
+###  is your feature request related to a problem?
+a clear and concise description of what the problem is.
+
+###  solution pitch
+a clear and concise description of what you want to happen and how it improves the forensic suite.
+
+###  alternatives considered
+a clear and concise description of any alternative solutions or features you've considered.
+
+###  additional context
+add any other context, code snippets, mockups, or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+### 📝 description
+briefly describe what this pr changes or adds to the project.
+
+### 🔗 related issue
+closes #
+
+### 🛠️ changes made
+* [ ] created/modified file X
+* [ ] fixed bug Y
+
+### 📋 Contribution Checklist
+- [ ] My code strictly adheres to the project guidelines.
+- [ ] I have verified that my files are placed in the correct directory.
+- [ ] I have tested my changes thoroughly on my local machine.
+- [ ] I have included interactive emojis and clean console/UI outputs.
+- [ ] **GSSoC 2026:** I have been formally assigned to this issue and noted it above.
+
+### 📸 screenshots / visual proof
+(if UI changes were made, drop screenshots here)


### PR DESCRIPTION
### 📝 description
added the pull request and issue templates to the repo so we finally have a structured way to handle features and bugs.

### 🔗 related issue
closes #126 

### 🛠️ changes made
* [x] created .github/ISSUE_TEMPLATE/feature_request.md for tracking new ideas
* [x] created .github/ISSUE_TEMPLATE/bug_report.md for documenting or any bugs
* [x] created .github/pull_request_template.md to keep our prs clean and organized
### 📸 screenshots / visual proof
<img width="371" height="248" alt="Screenshot 2026-05-19 154126" src="https://github.com/user-attachments/assets/d91b8d00-c919-404e-876b-7658e65a5de6" />

i am doing this as a gssoc '26 contributor. kindly assign the respective labels