### PR TITLE
fix(client): remove duplicate POST route handler and duplicate imports to fix compilation

### DIFF
--- a/client/app/api/analyze/route.ts
+++ b/client/app/api/analyze/route.ts
@@ -1,35 +1,3 @@
-import { NextRequest, NextResponse } from "next/server";
-
-export async function POST(request: NextRequest) {
-  try {
-    const formData = await request.formData();
-    const backendUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
-    const response = await fetch(`${backendUrl}/api/analyze`, {
-      method: "POST",
-      body: formData,
-    });
-
-    const contentType = response.headers.get("content-type") || "";
-    const responseBody = contentType.includes("application/json")
-      ? await response.json()
-      : await response.text();
-
-    if (!response.ok) {
-      console.error("Analyze proxy backend error:", response.status, responseBody);
-      return NextResponse.json(
-        { error: "Forensic backend error during file analysis." },
-        { status: response.status }
-      );
-    }
-
-    return NextResponse.json(responseBody, { status: response.status });
-  } catch (error) {
-    console.error("Analyze proxy request failed:", error);
-    return NextResponse.json(
-      { error: "Unable to reach the forensic backend service." },
-      { status: 502 }
-    );
-  }
 import { authOptions } from "@/lib/auth";
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";


### PR DESCRIPTION
This pull request resolves a build/compile-time crash caused by duplicate route exports and imports in the file analysis proxy.

### Changes
- Deleted the duplicate, unauthenticated `POST` route handler from `client/app/api/analyze/route.ts`.
- Cleaned up duplicate imports declared in the middle of the file.
- Preserved the production-grade, session-authenticated `POST` API route handler that securely interacts with the backend.

Closes #142
