### PR TITLE
fix(server): prevent UnboundLocalError in forensic pipeline finally block

### DIFF
--- a/Server/main.py
+++ b/Server/main.py
@@ -70,6 +70,9 @@ async def get_case_stats():
 
 @app.post("/api/analyze")
 async def run_forensic_pipeline(request: Request, file: UploadFile = File(...)):
+    tmp_path = None
+    archive_metadata = None
+
     try:
         validate_analyze_api_key(request.headers.get("x-analyze-key"))
 
@@ -79,9 +82,6 @@ async def run_forensic_pipeline(request: Request, file: UploadFile = File(...)):
                 status_code=400,
                 detail=f"File type '{ext}' is not permitted. Allowed types: {', '.join(sorted(ALLOWED_EXTENSIONS))}"
             )
-
-        tmp_path = None
-        archive_metadata = None
 
         try:
             tmp_path, _ = await stream_upload_to_tempfile(file, ext)


### PR DESCRIPTION
This pull request fixes a scope issue in the forensic analyze route handler that raises UnboundLocalErrors.

### Changes
- Moved `tmp_path = None` and `archive_metadata = None` declarations to the very top of `run_forensic_pipeline` in `Server/main.py`.
- Ensures that if validation raises an `HTTPException`, the local variables are already defined as `None` when referenced by the outer `finally` block, preventing an `UnboundLocalError`.

Closes #144
