### PR TITLE
fix: remove contradictory initialized.current guard from checkInterval in Terminal.tsx

### DIFF
--- a/client/components/Terminal.tsx
+++ b/client/components/Terminal.tsx
@@ -110,12 +110,12 @@ function ForensicTerminalContent({ isDark }: { isDark: boolean }) {
 
     let initTimeout: NodeJS.Timeout;
     const checkInterval = setInterval(() => {
-      if (terminalRef.current && terminalRef.current.offsetWidth > 0 && initialized.current === false) {
+      if (terminalRef.current && terminalRef.current.offsetWidth > 0) {
         clearInterval(checkInterval);
-        
+
         try {
           term.open(terminalRef.current);
-          
+
           initTimeout = setTimeout(() => {
             if (termInstance.current && terminalRef.current && terminalRef.current.offsetParent) {
               try {
@@ -139,9 +139,9 @@ function ForensicTerminalContent({ isDark }: { isDark: boolean }) {
       if (!termInstance.current || !terminalRef.current || !terminalRef.current.offsetParent) return;
       try {
         fitAddon.fit();
-        } catch {
-          // Ignore dispose errors
-        }
+      } catch {
+        // Ignore fit errors
+      }
     });
     resizeObserver.observe(terminalRef.current);
 
@@ -172,11 +172,11 @@ function ForensicTerminalContent({ isDark }: { isDark: boolean }) {
       if (initTimeout) clearTimeout(initTimeout);
       keyDisposable.dispose();
       resizeObserver.disconnect();
-      
+
       const toDispose = termInstance.current;
       termInstance.current = null;
       initialized.current = false;
-      
+
       if (toDispose) {
         try {
           toDispose.dispose();
@@ -199,7 +199,7 @@ function ForensicTerminalContent({ isDark }: { isDark: boolean }) {
   }, [isDark]);
 
   return (
-    <div 
+    <div
       className="bg-white dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-2xl p-4 mt-8 shadow-sm cursor-text"
       onClick={() => {
         if (termInstance.current) {
@@ -216,9 +216,9 @@ function ForensicTerminalContent({ isDark }: { isDark: boolean }) {
         </span>
       </div>
 
-      <div 
-        ref={terminalRef} 
-        className={`h-64 rounded-lg overflow-hidden transition-colors duration-300 ${isDark ? "bg-slate-950" : "bg-white"}`} 
+      <div
+        ref={terminalRef}
+        className={`h-64 rounded-lg overflow-hidden transition-colors duration-300 ${isDark ? "bg-slate-950" : "bg-white"}`}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Fixes #157

## Root Cause

In `client/components/Terminal.tsx`, the `useEffect` sets `initialized.current = true` at the very start to prevent the effect from running twice:

```ts
if (!terminalRef.current || initialized.current) return;
initialized.current = true;  // set to true here
```

The `checkInterval` then polls every 50ms waiting for the DOM element to have a non-zero width before calling `term.open()`. However, it included a contradictory guard:

```ts
// Before (broken)
const checkInterval = setInterval(() => {
  if (terminalRef.current && terminalRef.current.offsetWidth > 0 && initialized.current === false) {
```

Because `initialized.current` was already set to `true` before the interval was created, the condition `initialized.current === false` is **never true**. The interval fires every 50ms, evaluates to `false`, and exits without ever calling `term.open()`. The terminal element is never attached to the DOM and remains blank permanently.

## Fix

Remove the contradictory `initialized.current === false` check from the interval condition. The interval only needs to wait for the element to be visible and painted:

```ts
// After (fixed)
const checkInterval = setInterval(() => {
  if (terminalRef.current && terminalRef.current.offsetWidth > 0) {
```

The existing guard at the top of the effect (`if (!terminalRef.current || initialized.current) return`) already prevents double-initialization, so removing the condition from the interval is safe.

## Additional Cleanup

- Fixed a misaligned closing brace in the `resizeObserver` try/catch block (indentation was inconsistent with the rest of the file)

## Files Changed

- `client/components/Terminal.tsx`: removed `&& initialized.current === false` from the `checkInterval` condition

## Testing

1. Navigate to the investigator workstation dashboard
2. Observe the Sleuth Kit terminal panel
3. Verify the terminal initializes, displays the welcome banner, and shows the `$` prompt
4. Run `help`, `autopsy`, `fls <image>` and other commands to confirm full functionality
5. Verify theme switching (dark/light) updates terminal colors correctly