### PR TITLE
Fix: Add magic byte signatures for PCAP and PCAPNG (#152)

### DIFF
--- a/Server/engine.py
+++ b/Server/engine.py
@@ -49,6 +49,9 @@ class ForensicEngine:
             b"%PDF": "PDF Document",
             b"PK\x03\x04": "ZIP/Office Archive",
             b"MZ": "Executable (Warning)",
+            b"\xd4\xc3\xb2\xa1": "PCAP Network Capture (Little Endian)",
+            b"\xa1\xb2\xc3\xd4": "PCAP Network Capture (Big Endian)",
+            b"\x0a\x0d\x0d\x0a": "PCAPNG Network Capture",
         }
         try:
             with open(self.evidence_path, "rb") as f:

--- a/Server/tests/test_security.py
+++ b/Server/tests/test_security.py
@@ -79,6 +79,45 @@ class SecurityHelpersTests(unittest.TestCase):
         finally:
             Path(tmp_path).unlink(missing_ok=True)
 
+    def test_verify_file_signature_pcap_little_endian(self) -> None:
+        from engine import ForensicEngine
+        with tempfile.NamedTemporaryFile(suffix=".pcap", delete=False) as tmp:
+            tmp.write(b"\xd4\xc3\xb2\xa1somepcapdata")
+            tmp_path = tmp.name
+        try:
+            engine = ForensicEngine(tmp_path)
+            verified, sig_name = engine.verify_file_signature()
+            self.assertTrue(verified)
+            self.assertEqual(sig_name, "PCAP Network Capture (Little Endian)")
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+    def test_verify_file_signature_pcap_big_endian(self) -> None:
+        from engine import ForensicEngine
+        with tempfile.NamedTemporaryFile(suffix=".pcap", delete=False) as tmp:
+            tmp.write(b"\xa1\xb2\xc3\xd4somepcapdata")
+            tmp_path = tmp.name
+        try:
+            engine = ForensicEngine(tmp_path)
+            verified, sig_name = engine.verify_file_signature()
+            self.assertTrue(verified)
+            self.assertEqual(sig_name, "PCAP Network Capture (Big Endian)")
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+    def test_verify_file_signature_pcapng(self) -> None:
+        from engine import ForensicEngine
+        with tempfile.NamedTemporaryFile(suffix=".pcapng", delete=False) as tmp:
+            tmp.write(b"\x0a\x0d\x0d\x0asomepcapngdata")
+            tmp_path = tmp.name
+        try:
+            engine = ForensicEngine(tmp_path)
+            verified, sig_name = engine.verify_file_signature()
+            self.assertTrue(verified)
+            self.assertEqual(sig_name, "PCAPNG Network Capture")
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### 📝 description
Fixes a bug where uploading valid network capture files (`.pcap`, `.pcapng`) triggered a false-positive threat alert (Elevated - Signature Mismatch). 

This occurred because the `verify_file_signature()` function in the `ForensicEngine` only checked for PNG, JPEG, PDF, ZIP, and MZ executable headers, and flagged any other formats (including PCAP/PCAPNG) as "Unknown/Generic Data". This PR adds the standard magic byte signatures for libpcap PCAP (Big Endian and Little Endian) and PCAPNG network captures to resolve the signature mismatches.

---

### 🔗 related issue
closes #152 

---

### 🛠️ changes made

* **`Server/engine.py`**:
  * Updated `verify_file_signature()`'s `signatures` dictionary to include:
    * PCAP Network Capture (Little Endian): `b"\xd4\xc3\xb2\xa1"`
    * PCAP Network Capture (Big Endian): `b"\xa1\xb2\xc3\xd4"`
    * PCAPNG Network Capture: `b"\x0a\x0d\x0d\x0a"`

* **`Server/tests/test_security.py`**:
  * Added three unit tests to test the magic byte signature verification of PCAP Little Endian, PCAP Big Endian, and PCAPNG files.

---

### 📋 Contribution Checklist
- [x] My code strictly adheres to the project guidelines.
- [x] I have verified that my files are placed in the correct directory.
- [x] I have tested my changes thoroughly on my local machine (`python -m unittest discover -s tests` succeeds fully with all 6 tests passing).
- [x] I have included interactive emojis and clean console/UI outputs.
- [x] **GSSoC 2026:** I have been formally assigned to this issue and noted it above.

---

### 📸 screenshots / visual proof
*(Not applicable since visual layouts were preserved and only backend engine logic was updated)*
