### PR TITLE
fix(server): remove malformed stats endpoint header to resolve syntax error

### DIFF
--- a/Server/main.py
+++ b/Server/main.py
@@ -40,14 +40,6 @@ ALLOWED_EXTENSIONS = {
 MAX_FILE_SIZE = 500 * 1024 * 1024
 
 
-# Dashboard statistics endpoint
-@app.get("/api/stats")
-async def get_case_stats():
-    try:
-        from supabase import create_client
-        url = os.getenv("SUPABASE_URL")
-        key = os.getenv("SUPABASE_ANON_KEY")
-
 def get_api_user(authorization: str | None = Header(None)):
     if not authorization:
         raise HTTPException(status_code=401, detail="Authorization header missing")


### PR DESCRIPTION
Closes #235 

### Description
Removed a truncated, duplicated, and invalid `get_case_stats` endpoint block in `main.py` which was causing indentation and syntax errors.

### Changes
- Modified `Server/main.py` to delete lines 43 to 50, leaving the fully functional `get_case_stats` definition (line 78) intact.

### Verification
- Ran FastAPI uvicorn start check. The server boots cleanly with zero indentation errors.
