### PR TITLE
fix(analyze): record authenticated user as investigator instead of hardcoded email

### DIFF
--- a/Server/main.py
+++ b/Server/main.py
@@ -72,7 +72,11 @@ def write_audit(entry: str):
 async def get_case_stats(current_user: dict = Depends(get_api_user)):
     ...
 @app.post("/api/analyze")
-async def run_forensic_pipeline(request: Request, file: UploadFile = File(...)):
+async def run_forensic_pipeline(
+    request: Request,
+    file: UploadFile = File(...),
+    current_user: dict = Depends(get_api_user),
+):
     tmp_path = None
     archive_metadata = None
 
@@ -124,7 +128,7 @@ async def run_forensic_pipeline(request: Request, file: UploadFile = File(...)):
                     "hash_value": f"SHA256:{report['hash_sha256']}",
                     "file_size": f"{report['metadata']['size_bytes']} bytes",
                     "status": "Pending Review",
-                    "investigator": "system@forensics.com",
+                    "investigator": current_user["id"],
                     "metadata": {
                         "magic_signature": report['metadata']['magic_signature'],
                         # In a real app we'd try to extract device IDs from EXIF/metadata


### PR DESCRIPTION
## Description

The `/api/analyze` endpoint in `Server/main.py` recorded every uploaded evidence file in the Supabase `cases` table with the `investigator` field set to the literal string `system@forensics.com`, regardless of which authenticated user actually submitted the file. This broke chain-of-custody attribution and rendered the audit trail unreliable for any accountability review.

The `get_api_user` dependency was already available in the codebase and was correctly applied to other endpoints such as `GET /api/stats`. This PR applies the same dependency to `POST /api/analyze` so the authenticated caller's identity is recorded in the case record.

## Related Issues

Closes #246

## Type of Change

- [x] Bug fix

## Changes Made

- **`Server/main.py`**: Added `current_user: dict = Depends(get_api_user)` to `run_forensic_pipeline`. Replaced the hardcoded `"system@forensics.com"` string with `current_user["id"]`, which is set to `"admin"` or `"investigator"` by `get_api_user` based on the Bearer token supplied in the request.

## Screenshots / Demo

Not applicable. This is a backend data-integrity fix with no UI change.

## Testing Done

1. Start the server with valid `ADMIN_TOKEN` and `INVESTIGATOR_TOKEN` environment variables set.
2. Submit a file to `POST /api/analyze` with `Authorization: Bearer <ADMIN_TOKEN>` and a valid `x-analyze-key`.
3. Confirm the resulting row in the Supabase `cases` table shows `investigator = "admin"`.
4. Repeat with `Authorization: Bearer <INVESTIGATOR_TOKEN>`.
5. Confirm `investigator = "investigator"` in the inserted row.
6. Submit a request with no `Authorization` header -- confirm a `401` is returned and no row is inserted.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] I have read the CODE_OF_CONDUCT.md
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] I have updated documentation where required
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue
- [x] I have not used any AI-generated content in this PR

## Updated relevant documentation (if needed)

No documentation changes required. The behavior change is captured in the issue and this PR description.

---

Could you please add the appropriate **NSoC '26** label to this PR? It helps with tracking and scoring under NSoC '26. Thank you!