### PR TITLE
style: fix React Flow Evidence Graph styles to dynamically adapt to themes

### DIFF
--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -101,27 +101,49 @@ html:not(.dark) .border {
 /* Evidence Graph / React Flow   */
 /* ----------------------------- */
 
-/* Override React Flow background & controls for dark theme */
-.react-flow__background {
+/* Override React Flow background & controls for light vs dark theme */
+.dark .react-flow__background {
   background-color: #020617 !important;
 }
 
-.react-flow__controls {
+html:not(.dark) .react-flow__background {
+  background-color: #f8fafc !important;
+}
+
+.dark .react-flow__controls {
   background: #0f172a !important;
   border: 1px solid #1e293b !important;
   border-radius: 8px !important;
   overflow: hidden;
 }
 
-.react-flow__controls-button {
+html:not(.dark) .react-flow__controls {
+  background: #ffffff !important;
+  border: 1px solid #e2e8f0 !important;
+  border-radius: 8px !important;
+  overflow: hidden;
+}
+
+.dark .react-flow__controls-button {
   background: #0f172a !important;
   border-bottom: 1px solid #1e293b !important;
   color: #94a3b8 !important;
   fill: #94a3b8 !important;
 }
 
-.react-flow__controls-button:hover {
+html:not(.dark) .react-flow__controls-button {
+  background: #ffffff !important;
+  border-bottom: 1px solid #e2e8f0 !important;
+  color: #64748b !important;
+  fill: #64748b !important;
+}
+
+.dark .react-flow__controls-button:hover {
   background: #1e293b !important;
+}
+
+html:not(.dark) .react-flow__controls-button:hover {
+  background: #f1f5f9 !important;
 }
 
 .react-flow__minimap {

--- a/client/components/graph/EvidenceGraph.tsx
+++ b/client/components/graph/EvidenceGraph.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTheme } from "next-themes";
 import {
   ReactFlow,
   Background,
@@ -223,6 +224,8 @@ function getLayoutedElements(rawNodes: RawNode[], rawEdges: RawEdge[], strategy:
 
 function InnerGraph({ data }: EvidenceGraphProps) {
   const { fitView, setCenter } = useReactFlow();
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
 
   const [layoutStrategy, setLayoutStrategy] = useState<LayoutStrategy>("flat");
 
@@ -378,7 +381,7 @@ function InnerGraph({ data }: EvidenceGraphProps) {
   };
 
   return (
-    <div className="absolute inset-0 bg-slate-950">
+    <div className="absolute inset-0 bg-slate-50 dark:bg-slate-950 transition-colors duration-300">
       {/* Toolbar */}
       <div className="absolute top-4 left-4 right-4 z-10 flex flex-wrap items-center gap-2 pointer-events-none">
         {/* Search */}
@@ -390,38 +393,38 @@ function InnerGraph({ data }: EvidenceGraphProps) {
             placeholder="Search nodes..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="bg-slate-900/90 backdrop-blur border border-slate-700 rounded-lg pl-8 pr-3 py-1.5 text-[11px] font-mono text-white placeholder-slate-500 focus:outline-none focus:border-emerald-500/50 w-44 transition-all"
+            className="bg-white/90 dark:bg-slate-900/90 backdrop-blur border border-slate-200 dark:border-slate-700 rounded-lg pl-8 pr-3 py-1.5 text-[11px] font-mono text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none focus:border-emerald-500/50 w-44 transition-all"
           />
           {searchQuery && (
-            <button onClick={() => setSearchQuery("")} className="absolute right-2 top-1/2 -translate-y-1/2 text-slate-500 hover:text-white">
+            <button onClick={() => setSearchQuery("")} className="absolute right-2 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-700 dark:hover:text-white">
               <X className="w-3 h-3" />
             </button>
           )}
         </div>
 
         {/* Layout Strategy Select */}
-        <div className="pointer-events-auto flex items-center gap-2 bg-slate-900/90 backdrop-blur border border-slate-700 rounded-lg px-2 py-1">
-          <span className="text-[10px] font-mono text-slate-400 pl-1">Layout:</span>
+        <div className="pointer-events-auto flex items-center gap-2 bg-white/90 dark:bg-slate-900/90 backdrop-blur border border-slate-200 dark:border-slate-700 rounded-lg px-2 py-1 transition-colors">
+          <span className="text-[10px] font-mono text-slate-500 dark:text-slate-400 pl-1">Layout:</span>
           <select
             value={layoutStrategy}
             onChange={(e) => setLayoutStrategy(e.target.value as LayoutStrategy)}
-            className="bg-transparent border-none outline-none text-[10px] font-mono font-bold text-slate-300 uppercase tracking-wide cursor-pointer focus:ring-0"
+            className="bg-transparent border-none outline-none text-[10px] font-mono font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wide cursor-pointer focus:ring-0"
           >
-            <option value="flat" className="bg-slate-900 text-slate-300">Flat</option>
-            <option value="type" className="bg-slate-900 text-slate-300">Group by Type</option>
-            <option value="case" className="bg-slate-900 text-slate-300">Group by Case</option>
+            <option value="flat" className="bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-300">Flat</option>
+            <option value="type" className="bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-300">Group by Type</option>
+            <option value="case" className="bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-300">Group by Case</option>
           </select>
         </div>
 
         {/* Type filters */}
-        <div className="pointer-events-auto flex items-center gap-1 bg-slate-900/90 backdrop-blur border border-slate-700 rounded-lg px-2 py-1">
+        <div className="pointer-events-auto flex items-center gap-1 bg-white/90 dark:bg-slate-900/90 backdrop-blur border border-slate-200 dark:border-slate-700 rounded-lg px-2 py-1 transition-colors">
           <Filter className="w-3 h-3 text-slate-500 mr-1" />
           {NODE_FILTER_OPTIONS.map((opt) => (
             <button
               key={opt.type}
               onClick={() => toggleFilter(opt.type)}
               style={activeFilters.has(opt.type) ? { backgroundColor: opt.color + "30", borderColor: opt.color } : {}}
-              className="text-[9px] font-mono font-bold uppercase tracking-widest px-2 py-0.5 rounded border border-transparent hover:border-slate-600 text-slate-400 hover:text-white transition-all"
+              className="text-[9px] font-mono font-bold uppercase tracking-widest px-2 py-0.5 rounded border border-transparent hover:border-slate-300 dark:hover:border-slate-600 text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-all"
             >
               {opt.label}
             </button>
@@ -429,17 +432,17 @@ function InnerGraph({ data }: EvidenceGraphProps) {
         </div>
 
         {/* Stats */}
-        <div className="pointer-events-auto ml-auto flex items-center gap-3 bg-slate-900/90 backdrop-blur border border-slate-700 rounded-lg px-3 py-1.5">
-          <span className="text-[9px] font-mono text-slate-400">
-            <span className="text-emerald-400 font-bold">{data.stats.total_nodes}</span> nodes
+        <div className="pointer-events-auto ml-auto flex items-center gap-3 bg-white/90 dark:bg-slate-900/90 backdrop-blur border border-slate-200 dark:border-slate-700 rounded-lg px-3 py-1.5 transition-colors">
+          <span className="text-[9px] font-mono text-slate-600 dark:text-slate-400">
+            <span className="text-emerald-500 dark:text-emerald-400 font-bold">{data.stats.total_nodes}</span> nodes
           </span>
-          <span className="text-[9px] font-mono text-slate-400">
-            <span className="text-blue-400 font-bold">{data.stats.total_edges}</span> edges
+          <span className="text-[9px] font-mono text-slate-600 dark:text-slate-400">
+            <span className="text-blue-500 dark:text-blue-400 font-bold">{data.stats.total_edges}</span> edges
           </span>
           {data.stats.suspicious_count > 0 && (
             <button
               onClick={() => setShowAlerts((v) => !v)}
-              className="flex items-center gap-1 text-[9px] font-mono text-red-400 font-bold animate-pulse"
+              className="flex items-center gap-1 text-[9px] font-mono text-red-500 dark:text-red-400 font-bold animate-pulse"
             >
               <AlertTriangle className="w-3 h-3" />
               {data.stats.suspicious_count} alerts
@@ -455,33 +458,33 @@ function InnerGraph({ data }: EvidenceGraphProps) {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 20 }}
-            className="absolute bottom-20 left-4 z-10 w-72 bg-slate-900/95 backdrop-blur border border-red-500/30 rounded-xl shadow-xl overflow-hidden"
+            className="absolute bottom-20 left-4 z-10 w-72 bg-white/95 dark:bg-slate-900/95 backdrop-blur border border-red-500/20 dark:border-red-500/30 rounded-xl shadow-xl overflow-hidden transition-colors"
           >
             <div className="flex items-center justify-between px-3 py-2 border-b border-red-500/20">
               <div className="flex items-center gap-2">
-                <AlertTriangle className="w-3.5 h-3.5 text-red-400" />
-                <span className="text-[10px] font-mono font-bold text-red-400 uppercase tracking-widest">
+                <AlertTriangle className="w-3.5 h-3.5 text-red-500 dark:text-red-400" />
+                <span className="text-[10px] font-mono font-bold text-red-500 dark:text-red-400 uppercase tracking-widest">
                   Suspicious Patterns
                 </span>
               </div>
-              <button onClick={() => setShowAlerts(false)} className="text-slate-500 hover:text-white transition-colors">
+              <button onClick={() => setShowAlerts(false)} className="text-slate-500 hover:text-slate-700 dark:hover:text-white transition-colors">
                 <X className="w-3.5 h-3.5" />
               </button>
             </div>
-            <div className="max-h-40 overflow-y-auto divide-y divide-slate-800">
+            <div className="max-h-40 overflow-y-auto divide-y divide-slate-100 dark:divide-slate-800">
               {data.suspicious_patterns.map((p) => (
                 <div key={p.id} className="px-3 py-2">
                   <div className="flex items-center gap-1.5 mb-1">
                     <span className={`text-[8px] font-bold uppercase px-1.5 py-0.5 rounded-full border font-mono ${
-                      p.severity === "high" ? "text-red-400 bg-red-500/10 border-red-500/30"
-                        : p.severity === "medium" ? "text-yellow-400 bg-yellow-500/10 border-yellow-500/30"
-                        : "text-slate-400 bg-slate-500/10 border-slate-500/30"
+                      p.severity === "high" ? "text-red-500 bg-red-500/10 border-red-500/30 dark:text-red-400"
+                        : p.severity === "medium" ? "text-yellow-600 bg-yellow-500/10 border-yellow-500/30 dark:text-yellow-400"
+                        : "text-slate-500 bg-slate-500/10 border-slate-500/30 dark:text-slate-400"
                     }`}>
                       {p.severity}
                     </span>
-                    <span className="text-[9px] font-mono text-slate-400">{p.type.replace(/_/g, " ")}</span>
+                    <span className="text-[9px] font-mono text-slate-500 dark:text-slate-400">{p.type.replace(/_/g, " ")}</span>
                   </div>
-                  <p className="text-[10px] text-slate-300 leading-relaxed">{p.description}</p>
+                  <p className="text-[10px] text-slate-700 dark:text-slate-300 leading-relaxed">{p.description}</p>
                 </div>
               ))}
             </div>
@@ -501,17 +504,17 @@ function InnerGraph({ data }: EvidenceGraphProps) {
         onNodeDoubleClick={onNodeDoubleClick}
         fitView
         fitViewOptions={{ padding: 0.2 }}
-        className="bg-slate-950"
-        colorMode="dark"
+        className="bg-slate-50 dark:bg-slate-950 transition-colors"
+        colorMode={isDark ? "dark" : "light"}
       >
-        <Background color="#1e293b" gap={24} size={1} />
+        <Background color={isDark ? "#334155" : "#cbd5e1"} gap={24} size={1} />
         <Controls
           position="bottom-right"
-          className="!bg-slate-900 !border-slate-700 [&>button]:!bg-slate-900 [&>button]:!border-slate-700 [&>button]:!text-slate-400"
+          className="!bg-white dark:!bg-slate-900 !border-slate-200 dark:!border-slate-700 [&>button]:!bg-white dark:[&>button]:!bg-slate-900 [&>button]:!border-slate-200 dark:[&>button]:!border-slate-700 [&>button]:!text-slate-600 dark:[&>button]:!text-slate-400 [&>svg]:!fill-current"
         />
         <MiniMap
           position="bottom-left"
-          style={{ background: "#0f172a", border: "1px solid #1e293b" }}
+          style={{ background: isDark ? "#0f172a" : "#ffffff", border: isDark ? "1px solid #1e293b" : "1px solid #e2e8f0" }}
           nodeColor={(n) => {
             const colorMap: Record<string, string> = {
               case: "#10b981", evidence: "#3b82f6", hash: "#a855f7",
@@ -519,7 +522,7 @@ function InnerGraph({ data }: EvidenceGraphProps) {
             };
             return colorMap[n.type as string] || "#475569";
           }}
-          maskColor="rgba(0,0,0,0.5)"
+          maskColor={isDark ? "rgba(0,0,0,0.5)" : "rgba(255,255,255,0.5)"}
         />
       </ReactFlow>
 


### PR DESCRIPTION
Closes #269 

# Summary
Refactors React Flow and Evidence Graph stylesheets and properties to dynamically adapt to light vs. dark mode theme settings.

# Changes Made
- Imported `useTheme` inside `client/components/graph/EvidenceGraph.tsx`.
- Assigned dynamic background grid colors and minimap settings.
- Scoped custom flow CSS rules inside `.dark` and `html:not(.dark)` inside `client/app/globals.css`.

# Testing
- Toggled resolving themes dynamically on the client dashboard.
- Verified perfect typography legibility and edge connections.

# Impact
Implements unified, professional theme consistency.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
