### PR TITLE
fix: remove duplicate allow_credentials keyword argument in FastAPI CORS middleware

### DIFF
--- a/Server/main.py
+++ b/Server/main.py
@@ -33,7 +33,6 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
-    allow_credentials=True,
 )
 
 


### PR DESCRIPTION
Closes #328 

# Summary
Resolved syntax error in FastAPI setup.

# Changes Made
- Removed the duplicate `allow_credentials` parameter from CORSMiddleware setup.

# Testing
- PyTest suites run cleanly.
- Confirmed server boots successfully without SyntaxErrors.

# Impact
Enables normal deployment and execution of the backend server.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
