### PR TITLE
fix: enforce const declaration for unchanged variables in csvExport

### DIFF
--- a/client/lib/csvExport.ts
+++ b/client/lib/csvExport.ts
@@ -28,7 +28,7 @@ export function formatCsvValue(value: unknown): string {
   if (value == null) return '""';
   
   // Safely handle nested objects/arrays to prevent "[object Object]" print bugs
-  let text = typeof value === "object" ? JSON.stringify(value) : String(value);
+  const text = typeof value === "object" ? JSON.stringify(value) : String(value);
   
   // RFC 4180 requirement: If quotes, commas, or line breaks exist, escape quotes and wrap in quotes
   if (/[",\r\n]/.test(text)) {


### PR DESCRIPTION
Closes #330 

# Summary
Fixed prefer-const linter violation in csvExport.

# Changes Made
- Changed `let text` to `const text` inside the `formatCsvValue` helper.

# Testing
- Verified eslint output.

# Impact
Keeps code quality compliant with strict repository rules.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
